### PR TITLE
Added an import to WORKSPACE for gtest. This pulls it down using the

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,0 +1,7 @@
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
+
+git_repository(
+  name = "gtest",
+  tag = "release-1.10.0",
+  remote = "https://github.com/google/googletest.git",
+)


### PR DESCRIPTION
`git_repository` rule.

TESTED=ran a simple test case with gtest.