### PR TITLE
Add empty Atlas god-class

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1,4 +1,4 @@
 alias(
-    name = "atlas",
-    actual = "//src:atlas",
+    name = "atlas_emu",
+    actual = "//src:atlas_emu",
 )

--- a/BUILD
+++ b/BUILD
@@ -1,0 +1,4 @@
+alias(
+    name = "atlas",
+    actual = "//src:atlas",
+)

--- a/src/BUILD
+++ b/src/BUILD
@@ -1,8 +1,10 @@
 cc_library(
     name = "atlas",
+    hdrs = [
+        "atlas.h",
+    ],
     srcs = [
         "atlas.cc",
-        "atlas.h",
     ]
 )
 

--- a/src/BUILD
+++ b/src/BUILD
@@ -1,13 +1,24 @@
 cc_library(
-    name = "atlas_core",
+    name = "atlas",
     srcs = [
         "atlas.cc",
         "atlas.h",
     ]
 )
 
+cc_test(
+    name = "atlas_test",
+    srcs = [
+        "atlas_test.cc",
+    ],
+    deps = [
+        ":atlas",
+        "@gtest//:gtest_main",
+    ],
+)
+
 cc_binary(
-    name = "atlas",
+    name = "atlas_emu",
     visibility = [
         "//visibility:public",
     ],
@@ -15,6 +26,6 @@ cc_binary(
         "main.cc",
     ],
     deps = [
-        ":atlas_core",
+        ":atlas",
     ]
 )

--- a/src/BUILD
+++ b/src/BUILD
@@ -1,0 +1,20 @@
+cc_library(
+    name = "atlas_core",
+    srcs = [
+        "atlas.cc",
+        "atlas.h",
+    ]
+)
+
+cc_binary(
+    name = "atlas",
+    visibility = [
+        "//visibility:public",
+    ],
+    srcs = [
+        "main.cc",
+    ],
+    deps = [
+        ":atlas_core",
+    ]
+)

--- a/src/atlas.cc
+++ b/src/atlas.cc
@@ -1,0 +1,9 @@
+#include "atlas.h"
+
+#include <iostream>
+
+Atlas::Atlas() {
+  std::cout << "Eventually we'll load a rom...not today" << std::endl;
+}
+
+Atlas::~Atlas() = default;

--- a/src/atlas.h
+++ b/src/atlas.h
@@ -1,0 +1,10 @@
+#ifndef ATLAS_H_
+#define ATLAS_H_
+
+class Atlas {
+ public:
+  Atlas();
+  ~Atlas();
+};
+
+#endif  // ATLAS_H_

--- a/src/atlas_test.cc
+++ b/src/atlas_test.cc
@@ -1,0 +1,6 @@
+#include "atlas.h"
+#include "gtest/gtest.h"
+
+TEST(AtlasTest, Instantiate) {
+  Atlas atlas;
+}

--- a/src/main.cc
+++ b/src/main.cc
@@ -1,0 +1,9 @@
+#include <iostream>
+
+#include "atlas.h"
+
+int main(int argc, char** argv) {
+  std::cout << "Welcome to AtlasEmu!" << std::endl;
+  Atlas atlas;
+  return 0;
+}


### PR DESCRIPTION
This class will serve as a jump off point for instantiating core
components, such as memory/cpu/gpu/etc. We are keeping main.cc as small
as possible, so that our unit tests for Atlas can have as much coverage
as possible.